### PR TITLE
Simplify testing job, add back caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,22 +15,22 @@ jobs:
       matrix:
         include:
           - runner: ubuntu-24.04
-            nixpkgs: github:NixOS/nixpkgs/nixos-24.11
+            input: nixpkgs
 
           - runner: ubuntu-24.04
-            nixpkgs: github:NixOS/nixpkgs/nixpkgs-unstable
+            input: nixpkgs-unstable
 
           - runner: ubuntu-24.04-arm
-            nixpkgs: github:NixOS/nixpkgs/nixos-24.11
+            input: nixpkgs
 
           - runner: ubuntu-24.04-arm
-            nixpkgs: github:NixOS/nixpkgs/nixpkgs-unstable
+            input: nixpkgs-unstable
 
           - runner: macos-14
-            nixpkgs: github:NixOS/nixpkgs/nixos-24.11
+            input: nixpkgs
 
           - runner: macos-14
-            nixpkgs: github:NixOS/nixpkgs/nixpkgs-unstable
+            input: nixpkgs-unstable
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout code
@@ -41,23 +41,41 @@ jobs:
       - name: Install Nix
         uses: nixbuild/nix-quick-install-action@v30
 
+      - name: Cache Nix
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-test-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-test-${{ runner.os }}-${{ runner.arch }}-
+
       - name: Test extensions
         shell: nix develop --command bash {0}
         run: |
           set -euxo pipefail
 
           # Plain
-          nix build .#zed-extensions.catppuccin --override-input nixpkgs ${{ matrix.nixpkgs }}
+          nix build .#zed-extensions.catppuccin \
+            --inputs-from . \
+            --override-input nixpkgs ${{ matrix.input }}
+
           tree result
 
           # Rust
-          nix build .#zed-extensions.nix --override-input nixpkgs ${{ matrix.nixpkgs }}
+          nix build .#zed-extensions.nix \
+            --inputs-from . \
+            --override-input nixpkgs ${{ matrix.input }}
+
           tree result
 
           # Monorepo Plain
-          nix build .#zed-extensions.aura-theme --override-input nixpkgs ${{ matrix.nixpkgs }}
+          nix build .#zed-extensions.aura-theme \
+            --inputs-from . \
+            --override-input nixpkgs ${{ matrix.input }}
+
           tree result
 
           # Monorepo Rust
-          nix build .#zed-extensions.ruff --override-input nixpkgs ${{ matrix.nixpkgs }}
+          nix build .#zed-extensions.ruff \
+            --inputs-from . \
+            --override-input nixpkgs ${{ matrix.input }}
+
           tree result

--- a/flake.lock
+++ b/flake.lock
@@ -16,9 +16,26 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1746576598,
+        "narHash": "sha256-FshoQvr6Aor5SnORVvh/ZdJ1Sa2U4ZrIMwKBX5k2wu0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b3582c75c7f21ce0b429898980eddbbf05c68e55",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "rust-overlay": "rust-overlay"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,10 @@
       url = "github:NixOS/nixpkgs/nixos-24.11";
     };
 
+    nixpkgs-unstable = {
+      url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    };
+
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
Rather than test against the latest nixpkgs/nixpkgs-unstable, we can stick to whatever is in our flake.

Hopefully this doesn't blow our cache limit.