### PR TITLE
Update to nixpkgs 25.05

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Cache Nix
         uses: nix-community/cache-nix-action@v6
         with:
-          primary-key: nix-sync-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-sync-${{ runner.os }}-${{ runner.arch }}-
+          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Sync extensions
         run: nix run .#nix-zed-extensions -- sync

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,12 +46,6 @@ jobs:
       - name: Install Nix
         uses: nixbuild/nix-quick-install-action@v30
 
-      - name: Cache Nix
-        uses: nix-community/cache-nix-action@v6
-        with:
-          primary-key: nix-test-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-test-${{ runner.os }}-${{ runner.arch }}-
-
       - name: Test extensions
         shell: nix develop --command bash {0}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,6 @@ on:
   workflow_dispatch:
   pull_request:
 
-concurrency:
-  group: test
-  cancel-in-progress: false
-
 jobs:
   test:
     strategy:
@@ -83,7 +79,7 @@ jobs:
           tree result
 
           # Monorepo Rust
-          nix build .#zed-extensions.ruff \
+          nix build .#zed-extensions.toml \
             --inputs-from . \
             --override-input nixpkgs ${{ matrix.input }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,16 +18,25 @@ jobs:
             input: nixpkgs
 
           - runner: ubuntu-24.04
+            input: nixpkgs-deprecated
+
+          - runner: ubuntu-24.04
             input: nixpkgs-unstable
 
           - runner: ubuntu-24.04-arm
             input: nixpkgs
+
+          - runner: ubuntu-24.04-arm
+            input: nixpkgs-deprecated
 
           - runner: ubuntu-24.04-arm
             input: nixpkgs-unstable
 
           - runner: macos-14
             input: nixpkgs
+
+          - runner: macos-14
+            input: nixpkgs-deprecated
 
           - runner: macos-14
             input: nixpkgs-unstable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bytes"
@@ -634,9 +634,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasmparser"
-version = "0.229.0"
+version = "0.231.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3b1f053f5d41aa55640a1fa9b6d1b8a9e4418d118ce308d20e24ff3575a8c"
+checksum = "b1ddaf0d6e069fcd98801b1bf030e3648897d9f09c45ac9ef566d068aca1b76f"
 dependencies = [
  "bitflags",
  "hashbrown",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ tokio = { version = "1.44", features = ["full"] }
 futures = "0.3"
 
 # WASM
-wasmparser = "0.229"
+wasmparser = "0.231"
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,27 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746557022,
-        "narHash": "sha256-QkNoyEf6TbaTW5UZYX0OkwIJ/ZMeKSSoOMnSDPQuol0=",
+        "lastModified": 1747953325,
+        "narHash": "sha256-y2ZtlIlNTuVJUZCqzZAhIw5rrKP4DOSklev6c8PyCkQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1d3aeb5a193b9ff13f63f4d9cc169fb88129f860",
+        "rev": "55d1f923c480dadce40f5231feb472e81b0bab48",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-deprecated": {
+      "locked": {
+        "lastModified": 1747862697,
+        "narHash": "sha256-U4HaNZ1W26cbOVm0Eb5OdGSnfQVWQKbLSPrSSa78KC0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2baa12ff69913392faf0ace833bc54bba297ea95",
         "type": "github"
       },
       "original": {
@@ -18,11 +34,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1746576598,
-        "narHash": "sha256-FshoQvr6Aor5SnORVvh/ZdJ1Sa2U4ZrIMwKBX5k2wu0=",
+        "lastModified": 1747958103,
+        "narHash": "sha256-qmmFCrfBwSHoWw7cVK4Aj+fns+c54EBP8cGqp/yK410=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3582c75c7f21ce0b429898980eddbbf05c68e55",
+        "rev": "fe51d34885f7b5e3e7b59572796e1bcb427eccb1",
         "type": "github"
       },
       "original": {
@@ -35,22 +51,21 @@
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
+        "nixpkgs-deprecated": "nixpkgs-deprecated",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": ["nixpkgs"]
       },
       "locked": {
-        "lastModified": 1746585402,
-        "narHash": "sha256-Pf+ufu6bYNA1+KQKHnGMNEfTwpD9ZIcAeLoE2yPWIP0=",
+        "lastModified": 1748054080,
+        "narHash": "sha256-rwFiLLNCwkj9bqePtH1sMqzs1xmohE0Ojq249piMzF4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "72dd969389583664f87aa348b3458f2813693617",
+        "rev": "2221d8d53c128beb69346fa3ab36da3f19bb1691",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,10 @@
 
   inputs = {
     nixpkgs = {
+      url = "github:NixOS/nixpkgs/nixos-25.05";
+    };
+
+    nixpkgs-deprecated = {
       url = "github:NixOS/nixpkgs/nixos-24.11";
     };
 

--- a/pkgs/wasip1-component-adapter/default.nix
+++ b/pkgs/wasip1-component-adapter/default.nix
@@ -20,18 +20,18 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "wasip1-component-adapter";
-  version = "32.0.0";
+  version = "33.0.0";
 
   src = fetchFromGitHub {
     owner = "bytecodealliance";
     repo = "wasmtime";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-MGeLnxUmhhuW1FInBCc1xzppgvf3W8J0sy9v9QjgBIA=";
+    hash = "sha256-/i//5kPN1/zQnfDZWuJldKdFWk/DKAf5b5P4F58rgPI=";
     fetchSubmodules = true;
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-m9TsTTx/ExqE9/W3xVkYxtgKh8AlGUJTlGPMIDK2xog=";
+  cargoHash = "sha256-4ziMGmBbQ4anXvF6wwK1ezYXHY7JBvMRmPDreNME0H8=";
 
   buildPhase = ''
     cargo build \


### PR DESCRIPTION
We'll maintain support for 24.11 as long as nixpkgs does.
Expecting to see a failure related to #20 here, if not, I'll be confused.
UPDATE: Actually, the lockfile issue doesn't affect Ruff, since it hasn't been released recently. Let's switch to testing the TOML extension for now.

Will probably run out of Actions cache now.
Maybe look into Depot or one of the Nix native CI approaches?
Garnix, DetSys, NixCI, NixBuild, Cachix, ...

Using the GitHub cache is a little naive anyways.
Rather have a proper Nix cache.
Maybe a hosted cache is all we need?

#### Depot

- Minimum $20/month cost.
- Mainly focused on Docker users.
- "Only" 25GB of cache.
- No Mac runners.

For now, just don't cache builds.