### PR TITLE
Resolve issues on Darwin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,28 +55,32 @@ jobs:
 
           # Plain
           nix build .#zed-extensions.catppuccin \
+            --quiet \
             --inputs-from . \
             --override-input nixpkgs ${{ matrix.input }}
 
-          tree result
+          tree result/share/zed/extensions/catppuccin
 
           # Rust
           nix build .#zed-extensions.nix \
+            --quiet \
             --inputs-from . \
             --override-input nixpkgs ${{ matrix.input }}
 
-          tree result
+          tree result/share/zed/extensions/nix
 
           # Monorepo Plain
           nix build .#zed-extensions.aura-theme \
+            --quiet \
             --inputs-from . \
             --override-input nixpkgs ${{ matrix.input }}
 
-          tree result
+          tree result/share/zed/extensions/aura-theme
 
           # Monorepo Rust
           nix build .#zed-extensions.toml \
+            --quiet \
             --inputs-from . \
             --override-input nixpkgs ${{ matrix.input }}
 
-          tree result
+          tree result/share/zed/extensions/toml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,8 @@ jobs:
             --override-input nixpkgs ${{ matrix.input }}
 
           tree result/share/zed/extensions/catppuccin
+          test -f result/share/zed/extensions/catppuccin/extension.toml
+          test -d result/share/zed/extensions/catppuccin/themes
 
           # Rust
           nix build .#zed-extensions.nix \
@@ -68,6 +70,10 @@ jobs:
             --override-input nixpkgs ${{ matrix.input }}
 
           tree result/share/zed/extensions/nix
+          test -f result/share/zed/extensions/nix/extension.toml
+          test -f result/share/zed/extensions/nix/extension.wasm
+          test -d result/share/zed/extensions/nix/grammars
+          test -d result/share/zed/extensions/nix/languages
 
           # Monorepo Plain
           nix build .#zed-extensions.aura-theme \
@@ -76,6 +82,8 @@ jobs:
             --override-input nixpkgs ${{ matrix.input }}
 
           tree result/share/zed/extensions/aura-theme
+          test -f result/share/zed/extensions/aura-theme/extension.toml
+          test -d result/share/zed/extensions/aura-theme/themes
 
           # Monorepo Rust
           nix build .#zed-extensions.toml \
@@ -84,3 +92,7 @@ jobs:
             --override-input nixpkgs ${{ matrix.input }}
 
           tree result/share/zed/extensions/toml
+          test -f result/share/zed/extensions/toml/extension.toml
+          test -f result/share/zed/extensions/toml/extension.wasm
+          test -d result/share/zed/extensions/toml/grammars
+          test -d result/share/zed/extensions/toml/languages

--- a/pkgs/buildZedExtension/default.nix
+++ b/pkgs/buildZedExtension/default.nix
@@ -37,8 +37,6 @@ lib.extendMkDerivation {
       ];
 
       buildPhase = ''
-        runHook preBuild
-
         ${lib.optionalString (extensionRoot != null) ''
           pushd ${extensionRoot}
         ''}
@@ -49,14 +47,10 @@ lib.extendMkDerivation {
         ${lib.optionalString (extensionRoot != null) ''
           popd
         ''}
-
-        runHook postBuild
       '';
 
       doCheck = true;
       checkPhase = ''
-        runHook preCheck
-
         ${lib.optionalString (extensionRoot != null) ''
           pushd ${extensionRoot}
         ''}
@@ -67,13 +61,9 @@ lib.extendMkDerivation {
         ${lib.optionalString (extensionRoot != null) ''
           popd
         ''}
-
-        runHook postCheck
       '';
 
       installPhase = ''
-        runHook preInstall
-
         mkdir -p $out/share/zed/extensions/${name}
 
         ${lib.optionalString (extensionRoot != null) ''
@@ -82,12 +72,6 @@ lib.extendMkDerivation {
 
         # Manifest
         cp extension.toml $out/share/zed/extensions/${name}
-
-        # Grammars
-        ${lib.concatMapStrings (grammar: ''
-          mkdir -p $out/share/zed/extensions/${name}/grammars
-          ln -s ${grammar}/share/zed/grammars/* $out/share/zed/extensions/${name}/grammars
-        '') grammars}
 
         # Assets
         for DIR in themes icons icon_themes languages; do
@@ -106,7 +90,11 @@ lib.extendMkDerivation {
           popd
         ''}
 
-        runHook postInstall
+        # Grammars
+        ${lib.concatMapStrings (grammar: ''
+          mkdir -p $out/share/zed/extensions/${name}/grammars
+          ln -s ${grammar}/share/zed/grammars/* $out/share/zed/extensions/${name}/grammars
+        '') grammars}
       '';
     };
 }

--- a/pkgs/buildZedGrammar/default.nix
+++ b/pkgs/buildZedGrammar/default.nix
@@ -33,8 +33,6 @@ lib.extendMkDerivation {
       ];
 
       buildPhase = ''
-        runHook preBuild
-
         mkdir -p $out/share/zed/grammars
 
         SRC="src/parser.c"
@@ -52,8 +50,6 @@ lib.extendMkDerivation {
           -o $out/share/zed/grammars/${name}.wasm \
           -I src \
           $SRC
-
-        runHook postBuild
       '';
 
       doCheck = false;

--- a/pkgs/buildZedRustExtension/default.nix
+++ b/pkgs/buildZedRustExtension/default.nix
@@ -55,8 +55,6 @@ lib.extendMkDerivation {
       ];
 
       buildPhase = ''
-        runHook preBuild
-
         ${lib.optionalString (extensionRoot != null) ''
           pushd ${extensionRoot}
         ''}
@@ -91,14 +89,10 @@ lib.extendMkDerivation {
         ${lib.optionalString (extensionRoot != null) ''
           popd
         ''}
-
-        runHook postBuild
       '';
 
       doCheck = true;
       checkPhase = ''
-        runHook preCheck
-
         ${lib.optionalString (extensionRoot != null) ''
           pushd ${extensionRoot}
         ''}
@@ -109,13 +103,9 @@ lib.extendMkDerivation {
         ${lib.optionalString (extensionRoot != null) ''
           popd
         ''}
-
-        runHook postCheck
       '';
 
       installPhase = ''
-        runHook preInstall
-
         mkdir -p $out/share/zed/extensions/${name}
 
         ${lib.optionalString (extensionRoot != null) ''
@@ -125,16 +115,18 @@ lib.extendMkDerivation {
         # Manifest
         cp extension.toml $out/share/zed/extensions/${name}
 
+        ${lib.optionalString (extensionRoot != null) ''
+          popd
+        ''}
+
         # WASM
         if [ -f "extension.wasm" ]; then
           cp extension.wasm $out/share/zed/extensions/${name}
         fi
 
-        # Grammars
-        ${lib.concatMapStrings (grammar: ''
-          mkdir -p $out/share/zed/extensions/${name}/grammars
-          ln -s ${grammar}/share/zed/grammars/* $out/share/zed/extensions/${name}/grammars
-        '') grammars}
+        ${lib.optionalString (extensionRoot != null) ''
+          pushd ${extensionRoot}
+        ''}
 
         # Assets
         for DIR in themes icons icon_themes languages; do
@@ -153,7 +145,11 @@ lib.extendMkDerivation {
           popd
         ''}
 
-        runHook postInstall
+        # Grammars
+        ${lib.concatMapStrings (grammar: ''
+          mkdir -p $out/share/zed/extensions/${name}/grammars
+          ln -s ${grammar}/share/zed/grammars/* $out/share/zed/extensions/${name}/grammars
+        '') grammars}
       '';
     };
 }

--- a/pkgs/buildZedRustExtension/default.nix
+++ b/pkgs/buildZedRustExtension/default.nix
@@ -7,7 +7,6 @@
   wasm-tools,
   jq,
   nix-zed-extensions,
-  libiconv,
   ...
 }:
 
@@ -47,8 +46,6 @@ lib.extendMkDerivation {
     {
       pname = "zed-extension-${name}";
       inherit name src version;
-
-      LIBRARY_PATH = lib.optionalString stdenv.isDarwin "${libiconv}/lib";
 
       nativeBuildInputs = [
         clang

--- a/pkgs/nix-zed-extensions/default.nix
+++ b/pkgs/nix-zed-extensions/default.nix
@@ -33,6 +33,8 @@ rustPlatform.buildRustPackage {
     lockFile = ../../Cargo.lock;
   };
 
+  doCheck = false;
+
   postInstall = ''
     wrapProgram $out/bin/nix-zed-extensions \
       --prefix PATH : ${


### PR DESCRIPTION
Tested locally, and seems libiconv isn't needed anymore with wasip2.

EDIT: Noticied an issue with how we copy the finished WASM, will fix it here too. 

Annoying that Zed just auto-downloads things so often that I don't notice issues like this.