### PR TITLE
Improve support for nested workspaces

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,25 +14,16 @@ jobs:
             input: nixpkgs
 
           - runner: ubuntu-24.04
-            input: nixpkgs-deprecated
-
-          - runner: ubuntu-24.04
             input: nixpkgs-unstable
 
           - runner: ubuntu-24.04-arm
             input: nixpkgs
 
           - runner: ubuntu-24.04-arm
-            input: nixpkgs-deprecated
-
-          - runner: ubuntu-24.04-arm
             input: nixpkgs-unstable
 
           - runner: macos-14
             input: nixpkgs
-
-          - runner: macos-14
-            input: nixpkgs-deprecated
 
           - runner: macos-14
             input: nixpkgs-unstable
@@ -48,51 +39,12 @@ jobs:
       - name: Install Nix
         uses: nixbuild/nix-quick-install-action@5bb6a3b3abe66fd09bbf250dce8ada94f856a703 # v30
 
+      - name: Cache Nix
+        uses: nix-community/cache-nix-action@135667ec418502fa5a3598af6fb9eb733888ce6a # v6.1.3
+        with:
+          primary-key: nix-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}-
+
       - name: Test extensions
         shell: nix develop --command bash {0}
-        run: |
-          set -euxo pipefail
-
-          # Plain
-          nix build .#zed-extensions.catppuccin \
-            --quiet \
-            --inputs-from . \
-            --override-input nixpkgs ${{ matrix.input }}
-
-          tree result/share/zed/extensions/catppuccin
-          test -f result/share/zed/extensions/catppuccin/extension.toml
-          test -d result/share/zed/extensions/catppuccin/themes
-
-          # Rust
-          nix build .#zed-extensions.nix \
-            --quiet \
-            --inputs-from . \
-            --override-input nixpkgs ${{ matrix.input }}
-
-          tree result/share/zed/extensions/nix
-          test -f result/share/zed/extensions/nix/extension.toml
-          test -f result/share/zed/extensions/nix/extension.wasm
-          test -d result/share/zed/extensions/nix/grammars
-          test -d result/share/zed/extensions/nix/languages
-
-          # Monorepo Plain
-          nix build .#zed-extensions.aura-theme \
-            --quiet \
-            --inputs-from . \
-            --override-input nixpkgs ${{ matrix.input }}
-
-          tree result/share/zed/extensions/aura-theme
-          test -f result/share/zed/extensions/aura-theme/extension.toml
-          test -d result/share/zed/extensions/aura-theme/themes
-
-          # Monorepo Rust
-          nix build .#zed-extensions.toml \
-            --quiet \
-            --inputs-from . \
-            --override-input nixpkgs ${{ matrix.input }}
-
-          tree result/share/zed/extensions/toml
-          test -f result/share/zed/extensions/toml/extension.toml
-          test -f result/share/zed/extensions/toml/extension.wasm
-          test -d result/share/zed/extensions/toml/grammars
-          test -d result/share/zed/extensions/toml/languages
+        run: ./scripts/test.sh ${{ matrix.input }}

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -63,6 +63,12 @@
         "path": "taplo",
         "arguments": ["lsp", "stdio"]
       }
+    },
+
+    "typos": {
+      "binary": {
+        "path": "typos-lsp"
+      }
     }
   }
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -635,9 +635,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/extensions.json
+++ b/extensions.json
@@ -55,7 +55,7 @@
       },
       "grammars": [],
       "kind": "rust",
-      "cargoHash": "sha256-OethAsPNEf12Sq+TuTVfhFOYAdJl+6hm+CQ0CPV4Uu4=",
+      "cargoHash": "sha256-8wMG+0Hi0Wf5rGqoaayiDZ2vW9wH3Rko66Dz2/B+yXw=",
       "cargoLock": {
         "lockFile": "/generated/activitywatch.lock",
         "outputHashes": {
@@ -762,7 +762,7 @@
       },
       "grammars": [],
       "kind": "rust",
-      "cargoHash": "sha256-qn1GgTeZKntH2S1dp+zaC9XO9yElV9l+LcVOOezZAo8=",
+      "cargoHash": "sha256-jaf4+nphO8Jy98P72szCYFaeCBT7fYGb6K3X+wqSXD4=",
       "cargoLock": {
         "lockFile": "/generated/basedpyright.lock"
       }
@@ -937,7 +937,7 @@
         "bicep_bicep_params"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-6Lw+qMEYN0tbYAwJO/g5cbsC4TJdMkvYfc0GBHG317w=",
+      "cargoHash": "sha256-iKrHkCUnausp2PawL4wJrI9YaMkiR/yCcrdRppG91J8=",
       "cargoLock": {
         "lockFile": "/generated/bicep.lock"
       }
@@ -980,7 +980,7 @@
         "bitbake_bitbake"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-a07ES0plasNieXAMblVYwDqGkv8/WbCkSKeUrXChpZs=",
+      "cargoHash": "sha256-ExtTXClpiM0hqRRCCGunmJr95jLIgKIc+XS6ucjt2HU=",
       "cargoLock": {
         "lockFile": "/generated/bitbake.lock"
       }
@@ -1116,7 +1116,7 @@
         "blueprint_blueprint"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-newk7v+f+6tzg3vfM/kE3ZMyK/a/9+zkugGyhI9ymaE=",
+      "cargoHash": "sha256-XJWEDsxEODFT/Y07YwVPB2DYWTxnfQhE9slA+mhoyQ4=",
       "cargoLock": {
         "lockFile": "/generated/blueprint.lock"
       }
@@ -1158,7 +1158,7 @@
         "bqn_bqn"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-DwFk8y3FisDTxTkY9CEuvvU3ORnP5KHB1bma8qaLdUQ=",
+      "cargoHash": "sha256-cID4N3w2xWf/lwsuMjXbbTonhRNjld7jvW6F+I+BDPM=",
       "cargoLock": {
         "lockFile": "/generated/bqn.lock"
       }
@@ -1218,7 +1218,7 @@
       },
       "grammars": [],
       "kind": "rust",
-      "cargoHash": "sha256-5yhp/S2/yEw8yRJuEf+Lg4U7BxBw686PBU3Pyjm0604=",
+      "cargoHash": "sha256-+KrViUbK5juEld8N+45pI7q7zcA6YXEGWi4l8qTWnYM=",
       "cargoLock": {
         "lockFile": "/generated/browser-tools-context-server.lock"
       }
@@ -1242,7 +1242,7 @@
         "c3_c3"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-7Ukotqqn/GDFGbJusIcbczubzUaxRMrClKAoa1bsmhw=",
+      "cargoHash": "sha256-gOYd0ORy8dkSrWCtGBbIsRATJh5wDQepd/eQ2tP9Y5U=",
       "cargoLock": {
         "lockFile": "/generated/c3.lock"
       }
@@ -1266,7 +1266,7 @@
         "caddyfile_caddyfile"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-Q5Xk36IQUzLvSdG1JBHs3E7+mu1xyp9HD+1fGLIQCLM=",
+      "cargoHash": "sha256-8CkpEWOu07ZyCUT1GrPo2JspN78GDTu7aSL/3h1UP+g=",
       "cargoLock": {
         "lockFile": "/generated/caddyfile.lock"
       }
@@ -1290,7 +1290,7 @@
         "cadence_cadence"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-PvuYD39YjkNUpg1gdh6PaSyLfHwyCCc2azYqU7zwWZU=",
+      "cargoHash": "sha256-6MWSarAggAq51a8WkXjqYdHNbflD/WLuRVQC92CbTWU=",
       "cargoLock": {
         "lockFile": "/generated/cadence.lock"
       }
@@ -2116,7 +2116,7 @@
       },
       "grammars": [],
       "kind": "rust",
-      "cargoHash": "sha256-U77ic6DJhcTyiuDKZD+QaieCX6dGophiQkxdKiUb4uA=",
+      "cargoHash": "sha256-mtUokijaObW5fN2+99WXATpCOQ3OziI9PglpCu5sReA=",
       "cargoLock": {
         "lockFile": "/generated/cspell.lock"
       }
@@ -2139,7 +2139,7 @@
       "extensionRoot": "crates/zed",
       "grammars": [],
       "kind": "rust",
-      "cargoHash": "sha256-SB/tUrNNuvYerWb70N70vSiTkVo+Q3Cxh3e8pMU/jEs=",
+      "cargoHash": "sha256-T9wJ1ZQr6Ak4PLz5zDO5PAeeNUU6ONPLMzeDSuyNfAE=",
       "cargoLock": {
         "lockFile": "/generated/css-modules-kit.lock"
       }
@@ -2360,7 +2360,7 @@
         "d_d"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-s53theMmhmX03mNfh1kY0EeR0eQktMkYCy+65c1Ylvs=",
+      "cargoHash": "sha256-YHiW8Y1cWR1OteGjEybY06n/qrUYn1hto0B/JxH2v3Q=",
       "cargoLock": {
         "lockFile": "/generated/d.lock"
       }
@@ -2589,10 +2589,10 @@
         "deepClone": false,
         "leaveDotGit": false
       },
-      "extensionRoot": "editors/zed",
       "grammars": [],
       "kind": "rust",
-      "cargoHash": "sha256-nGheg/HnkYsvfrsd/dPNbFQEHXFtjB5so436nrbKRqo="
+      "cargoRoot": "editors/zed",
+      "cargoHash": "sha256-F6Xbwup2Udc+HhKnna+f2wW7RzWATuI3zk0Ns4whfEw="
     },
     {
       "name": "devicetree",
@@ -2613,7 +2613,7 @@
         "devicetree_devicetree"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-RpmXqNNnHqARUVKQ4kMrbBq425i52Bav4vebLh461k4=",
+      "cargoHash": "sha256-qpTIG2FWV6Na4KrbGm1TTkqDFBGijh6C5Om4Ln1e608=",
       "cargoLock": {
         "lockFile": "/generated/devicetree.lock"
       }
@@ -3433,7 +3433,7 @@
         "fortran_fortran"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-/9mHl8TNXqqLLh7ArOVnKHzdaDK7Pm5fmnjJLeJcp3A=",
+      "cargoHash": "sha256-HNqUnUDDEbog2Z/3nahT1wCyMfmhCLQY5Ywfz1ydPZ0=",
       "cargoLock": {
         "lockFile": "/generated/fortran.lock"
       }
@@ -3558,7 +3558,7 @@
         "gdscript_godot_resource"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-/6KPGVWLkH9otb1i/ruH5XB1gsUQejdhcsOHu7R2BQY=",
+      "cargoHash": "sha256-bWt/tBf4C1mM7RN1l+dtwmObgxompU3AZw1MODtihxc=",
       "cargoLock": {
         "lockFile": "/generated/gdscript.lock"
       }
@@ -4423,7 +4423,7 @@
       },
       "grammars": [],
       "kind": "rust",
-      "cargoHash": "sha256-FjJcvTkQyzG/uTV6CuIACQV9LNk4TTDvi0V2SLsUquY=",
+      "cargoHash": "sha256-jg4ZwVptmR1iFNvraEH2XDatKLg/ryhlN3+XPkjSlG4=",
       "cargoLock": {
         "lockFile": "/generated/harper.lock"
       }
@@ -4491,7 +4491,7 @@
         "helm_helm"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-g5EdXS/C3wQikdQ0GPE03OtVbdiFxnUKIgs9DPIge98=",
+      "cargoHash": "sha256-KlbRIEK0SDYhNucOKNrcBxGVe3hMqqL6VveI+MfuNsc=",
       "cargoLock": {
         "lockFile": "/generated/helm.lock"
       }
@@ -4894,7 +4894,7 @@
       },
       "grammars": [],
       "kind": "rust",
-      "cargoHash": "sha256-+m7qGj9DgyN6hA3kU2/hktBhw5tpKGMOEIR6cSHO7kA=",
+      "cargoHash": "sha256-BKxt3y+Qc0HwI21IH+jTLLipvzgwlnAiP/NPCT+dVXk=",
       "cargoLock": {
         "lockFile": "/generated/iwe.lock"
       }
@@ -4939,7 +4939,7 @@
         "java_properties"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-IyIuNWJeDoM8Toy2EXNuPE5y8SsbJzPOEKv2idJXWPI=",
+      "cargoHash": "sha256-BourOI7R4FoPv0AqqFieadOuCwgh00kVrGInLMuvToA=",
       "cargoLock": {
         "lockFile": "/generated/java.lock"
       }
@@ -5427,7 +5427,7 @@
         "lean4_lean"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-eVhM8Zj9KoW5ivklETdedXJZB44gwu3pR4JS0yUFM6g=",
+      "cargoHash": "sha256-Kis3f7OWL97TkgeAIR19kWzGAQDWAVmmOW3+OYkgSr0=",
       "cargoLock": {
         "lockFile": "/generated/lean4.lock"
       }
@@ -5746,7 +5746,7 @@
         "luau_luau"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-38ltrnXz6XvE1y1sCUk2tm9IQoZip8lpUM7iOCW5mw4=",
+      "cargoHash": "sha256-cJ6xUkM49Jf78cWRfWO5YNq7JId7LdoORkxVN+IPDuY=",
       "cargoLock": {
         "lockFile": "/generated/luau.lock"
       }
@@ -6078,7 +6078,7 @@
       },
       "grammars": [],
       "kind": "rust",
-      "cargoHash": "sha256-9a2C0tjLCOkMMt9MaX5FP+VB53nPTGeoLIk6ZvwW3BY=",
+      "cargoHash": "sha256-mdAVhT+CWwLN9gT68XkDWmHKaBWr8yQeoh7eAFugErI=",
       "cargoLock": {
         "lockFile": "/generated/mcp-planetscale.lock"
       }
@@ -6138,7 +6138,7 @@
       },
       "grammars": [],
       "kind": "rust",
-      "cargoHash": "sha256-QR+jQzQQEw3/xRCl7PHtQhvuGugONZprCqcEEINcbb0=",
+      "cargoHash": "sha256-ke8hg/7Hj9o2FTySUsKWHi2RI9hpBSR5tsbpwX6vq8M=",
       "cargoLock": {
         "lockFile": "/generated/mcp-server-buildkite.lock"
       }
@@ -6350,7 +6350,7 @@
       },
       "grammars": [],
       "kind": "rust",
-      "cargoHash": "sha256-PiLSmJSv28tKFF603OjIvdLcLMgThEWaD3G3Nb44zC4=",
+      "cargoHash": "sha256-H7Tagz0MPiCvTMX2gY/xOJFYYu6zlU24G9Cli96g3fk=",
       "cargoLock": {
         "lockFile": "/generated/mcp-server-mui.lock"
       }
@@ -6564,7 +6564,7 @@
         "meson_meson"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-dubBl5ZJBA+yZbE5VJvsTAhHztE9HO52jKothFw6lOk=",
+      "cargoHash": "sha256-FfxxtJ4d2D/oi7O1tdC2k9xwQuydnKX4J+V8Q8DNuWY=",
       "cargoLock": {
         "lockFile": "/generated/meson.lock"
       }
@@ -6897,7 +6897,7 @@
         "motoko_motoko"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-vU6b3vvQvkQjAosKBa2Sh2FRuD7STwP6HZuBqd2MZoM=",
+      "cargoHash": "sha256-VpUEnO0FXqcV4LuISJmOVDaIZiz3mtPimrNvHrdWdOU=",
       "cargoLock": {
         "lockFile": "/generated/motoko.lock"
       }
@@ -7039,7 +7039,7 @@
         "neocmake_cmake"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-xUiy7FkAjlgZ7Dgr5WBO/EyYoT3WFdZ5Msw8FrG7/gI=",
+      "cargoHash": "sha256-jOj1c/gXxrVVZ1NaNeVw16OloXkf9zh1PPRYgsYo6XQ=",
       "cargoLock": {
         "lockFile": "/generated/neocmake.lock"
       }
@@ -7303,7 +7303,7 @@
         "nim_nim_format_string"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-Tt4nFIrBQwquQidBiQNWAb14m3bpAuV/U8fwUt6V0FU=",
+      "cargoHash": "sha256-s+Wz+3rqstGtQkg8eQi8hzSDfet/S4u9/pfHDUjdVQ4=",
       "cargoLock": {
         "lockFile": "/generated/nim.lock"
       }
@@ -7476,7 +7476,7 @@
       },
       "grammars": [],
       "kind": "rust",
-      "cargoHash": "sha256-dCc9VAp739h+wmLccQRZBnfsRc0PEQunDcfM0uUXbzg=",
+      "cargoHash": "sha256-e72nn4kP67bqWHlTkoLjdZpjVHXDYTjImd4dv8l+I8k=",
       "cargoLock": {
         "lockFile": "/generated/norminette.lock"
       }
@@ -8115,7 +8115,7 @@
         "pact_pact"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-8VI1ggVKeUrBDCg32qMiqMwjYaCBIvV3SDoZVwMIpks=",
+      "cargoHash": "sha256-JrIFqGOK/9KJe1sLvtMbqfi5rnO4oEnp2xvyL8C/jb8=",
       "cargoLock": {
         "lockFile": "/generated/pact.lock"
       }
@@ -8953,7 +8953,7 @@
       },
       "grammars": [],
       "kind": "rust",
-      "cargoHash": "sha256-+W98YAge2kY5vKpV1rfvPArfBnZg181vf6joEhVz7CM=",
+      "cargoHash": "sha256-4koth8gsiXW8MaufYE6W7KZHgv4BMpWe6/T3QONtxZk=",
       "cargoLock": {
         "lockFile": "/generated/python-refactoring.lock"
       }
@@ -9074,7 +9074,7 @@
         "r_r"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-I76TfMvdvG1g6PF6DnzL4oXohcPvvsx0XvBBTfBvqTo=",
+      "cargoHash": "sha256-dwgGrTm/fcqJXTlt66jKCRneF+PXkb5qkitXj1uAp5M=",
       "cargoLock": {
         "lockFile": "/generated/r.lock"
       }
@@ -9252,7 +9252,7 @@
         "rego_rego"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-4UV97PIOKvVTnmwimuX39HGhJ2tN+oRPg6ibLFeXKhI=",
+      "cargoHash": "sha256-IoXxWjr89fUSYYMwdaWlTXcJrosQG9kj0jj9TLIUiig=",
       "cargoLock": {
         "lockFile": "/generated/rego.lock"
       }
@@ -9392,7 +9392,7 @@
         "roc_roc"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-wlXct7zMJHjjaQCo6T5KFTeiUW9SivjSwzIt3ga7yPI=",
+      "cargoHash": "sha256-GNM0wNa9knni7Fd89WXcGbbPIfCyktoX8qd3LDrvCDM=",
       "cargoLock": {
         "lockFile": "/generated/roc.lock"
       }
@@ -9494,21 +9494,21 @@
         "rst_rst"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-h8U/shUT1k80bE008I7CL7BNojPoSWC4K4CKPEWD5iQ=",
+      "cargoHash": "sha256-scozDp65In1HqhHtHkyOZOpphaoci31kji59u7JbidE=",
       "cargoLock": {
         "lockFile": "/generated/rst.lock"
       }
     },
     {
       "name": "ruby",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "src": {
         "url": "https://github.com/zed-extensions/ruby",
-        "rev": "12fc52459ebe68d02f12f121eff20a127b4e902f",
-        "date": "2025-06-08T18:15:41+02:00",
-        "path": "/nix/store/s4w39py9q316w5qxjkk4nqs7qx5jr62p-ruby-12fc524",
-        "sha256": "0sy1bhdsr4by0ck8h3wsfi25yvvb6k8i6p32vcj6m0vmzrq42h8h",
-        "hash": "sha256-EEFBcP51g2ok22JcE9E0a29fRHSaD4gmA36RrBtcwWs=",
+        "rev": "43ff8ea0a4a15e505c0afacdc416c60872316cdd",
+        "date": "2025-06-26T21:47:00+02:00",
+        "path": "/nix/store/djmffgk8859mqyhc7n80xilji22wgnj6-ruby-43ff8ea",
+        "sha256": "1pc5drm8skmz3w9d7wg3l71nd03afh9005nqw19rsya7bwmfz0nr",
+        "hash": "sha256-2YLvKl9HeZ1T4NgWABJ0aoBmw6Hj8dMSH79OjWpuhd0=",
         "fetchLFS": false,
         "fetchSubmodules": false,
         "deepClone": false,
@@ -9520,7 +9520,7 @@
         "ruby_ruby"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-GbQdFm/hkERO+JvEpuBCPagZzOaTEen4Ea/c1dXegBA="
+      "cargoHash": "sha256-+Z/w2i+tH8SkMfXYvHgin3tHdMGM0HFgVP3Y+CtEtHs="
     },
     {
       "name": "ruff",
@@ -9683,7 +9683,7 @@
         "scala_scala"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-r7QsA+hRjE/2Ikm/f/HK9Amj5XwdGymYpdvyMb8n47w=",
+      "cargoHash": "sha256-YncxoTIUWHb2MhsIYtSbjeJqZS/dfw3AkVZdpxFzLr0=",
       "cargoLock": {
         "lockFile": "/generated/scala.lock"
       }
@@ -9873,7 +9873,7 @@
       },
       "grammars": [],
       "kind": "rust",
-      "cargoHash": "sha256-0Y14eds7OhFFNa3NeAope4Qd8i/BtCggHlhVArkCybg=",
+      "cargoHash": "sha256-a9zXwEzS1gaD0TiwbtbtLoLC7Le0CUlMdORrdvPDyuI=",
       "cargoLock": {
         "lockFile": "/generated/sieve.lock"
       }
@@ -10401,7 +10401,7 @@
       },
       "grammars": [],
       "kind": "rust",
-      "cargoHash": "sha256-8m6ZdNzqYPeuz5fJpSn57vDBCNjbUOs3Z1wZvgj7YK0=",
+      "cargoHash": "sha256-ZlLjkhnJRDlY/MKXGVbm1dHLgxapyT8zkHhKIPj1YuE=",
       "cargoLock": {
         "lockFile": "/generated/sqruff.lock"
       }
@@ -10524,7 +10524,7 @@
       },
       "grammars": [],
       "kind": "rust",
-      "cargoHash": "sha256-AI7g0oI8lJv5OP6ksSsMkmbzGGTrxUq8F7XhRRUhB6s=",
+      "cargoHash": "sha256-ERk1cHM2v0byt6EQQfnTgLs3+4UPr5iCijy2G2MDj24=",
       "cargoLock": {
         "lockFile": "/generated/stimulus.lock"
       }
@@ -10907,7 +10907,7 @@
         "templ_templ"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-rFGIkw4Xk4CRDngB66qbkz3yORDntI5Sag/RlKttIKQ=",
+      "cargoHash": "sha256-NKFhxal5+N/PgjOIdeU817uCk1YJRHyF/PJJx8/NKaI=",
       "cargoLock": {
         "lockFile": "/generated/templ.lock"
       }
@@ -11404,7 +11404,7 @@
       },
       "grammars": [],
       "kind": "rust",
-      "cargoHash": "sha256-dZIKAuIP1FFyqWi+xPqTH2wXLirmpwnmbdr3de14AiU=",
+      "cargoHash": "sha256-uIPEkp6w7e5FJT1PAmsNbxo35ucwEaYwJV6FOmBzFYQ=",
       "cargoLock": {
         "lockFile": "/generated/ty.lock"
       }
@@ -11426,7 +11426,7 @@
       },
       "grammars": [],
       "kind": "rust",
-      "cargoHash": "sha256-7ckfAyLSTvI6yOeiWTIzSMEBSi7RnDzFW78L7ulwqC0=",
+      "cargoHash": "sha256-hOA/1fw+FbydXo/trTgVxV1T2/85eWIPFUtRIdLuKLM=",
       "cargoLock": {
         "lockFile": "/generated/typos.lock"
       }
@@ -11641,7 +11641,7 @@
         "v_v"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-i5cwtjSwuqnti2rJpHPzwNdqdzC1x20x1sU9/ski0Hw=",
+      "cargoHash": "sha256-ahZRl2d4pnPFDybFxoGb3bD55jHtwdDuljUPYWGnvJ4=",
       "cargoLock": {
         "lockFile": "/generated/v.lock"
       }
@@ -11702,7 +11702,7 @@
         "vala_vala"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-3vUZCkbw7P1p4oBsgT7U4zNQIPR4b5uTJU9PoPdhJ+Y=",
+      "cargoHash": "sha256-NMLq+TBhqIjIodeFilfdBx7JFaZbtEXmY2A/6Js77OY=",
       "cargoLock": {
         "lockFile": "/generated/vala.lock"
       }
@@ -12396,7 +12396,7 @@
         "yara_yara"
       ],
       "kind": "rust",
-      "cargoHash": "sha256-qV1xnyTv4rxMziJX1LntI2GoNMfHISuhsn3WZ257MjQ=",
+      "cargoHash": "sha256-oi2fULI4jlKQf7gAJ8Rat6Y6mmBG1Wez9ibQiheTIAw=",
       "cargoLock": {
         "lockFile": "/generated/yara.lock"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750133334,
-        "narHash": "sha256-urV51uWH7fVnhIvsZIELIYalMYsyr2FCalvlRTzqWRw=",
+        "lastModified": 1750838302,
+        "narHash": "sha256-aVkL3/yu50oQzi2YuKo0ceiCypVZpZXYd2P2p1FMJM4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "36ab78dab7da2e4e27911007033713bab534187b",
+        "rev": "7284e2decc982b81a296ab35aa46e804baaa1cfe",
         "type": "github"
       },
       "original": {
@@ -16,29 +16,13 @@
         "type": "github"
       }
     },
-    "nixpkgs-deprecated": {
-      "locked": {
-        "lastModified": 1750151854,
-        "narHash": "sha256-3za+1J9FifMetO7E/kwgyW+dp+8pPBNlWKfcBovnn6M=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ad5c70bcc5cc5178205161b7a7d61a6e80f6d244",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1750215678,
-        "narHash": "sha256-Rc/ytpamXRf6z8UA2SGa4aaWxUXRbX2MAWIu2C8M+ok=",
+        "lastModified": 1750898778,
+        "narHash": "sha256-DXI7+SKDlTyA+C4zp0LoIywQ+BfdH5m4nkuxbWgV4UU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5395fb3ab3f97b9b7abca147249fa2e8ed27b192",
+        "rev": "322d8a3c6940039f7cff179a8b09c5d7ca06359d",
         "type": "github"
       },
       "original": {
@@ -67,7 +51,6 @@
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
-        "nixpkgs-deprecated": "nixpkgs-deprecated",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "rust-overlay": "rust-overlay"
       }
@@ -77,11 +60,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1750300711,
-        "narHash": "sha256-4XHPocwP+66PhxyyObPXfI+Rql4PoGe/xBK791N8I78=",
+        "lastModified": 1750991972,
+        "narHash": "sha256-jzadGZL1MtqmHb5AZcjZhHpNulOdMZPxf8Wifg8e5VA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4178888556c15e0a1c57850d2f103ac300a6e9e2",
+        "rev": "b6509555d8ffaa0727f998af6ace901c5b78dc26",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,10 +6,6 @@
       url = "github:NixOS/nixpkgs/nixos-25.05";
     };
 
-    nixpkgs-deprecated = {
-      url = "github:NixOS/nixpkgs/nixos-24.11";
-    };
-
     nixpkgs-unstable = {
       url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     };
@@ -99,6 +95,10 @@
 
             # CLI
             tree
+
+            # Spellchecking
+            typos
+            typos-lsp
 
             # GitHub
             zizmor

--- a/generated/activitywatch.lock
+++ b/generated/activitywatch.lock
@@ -205,9 +205,9 @@ checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
@@ -671,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
@@ -1114,9 +1114,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/basedpyright.lock
+++ b/generated/basedpyright.lock
@@ -50,9 +50,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/bicep.lock
+++ b/generated/bicep.lock
@@ -50,9 +50,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/bitbake.lock
+++ b/generated/bitbake.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/blueprint.lock
+++ b/generated/blueprint.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/bqn.lock
+++ b/generated/bqn.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/browser-tools-context-server.lock
+++ b/generated/browser-tools-context-server.lock
@@ -323,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -406,9 +406,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -543,9 +543,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/c3.lock
+++ b/generated/c3.lock
@@ -50,9 +50,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/caddyfile.lock
+++ b/generated/caddyfile.lock
@@ -50,9 +50,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/cadence.lock
+++ b/generated/cadence.lock
@@ -50,9 +50,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/cspell.lock
+++ b/generated/cspell.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/css-modules-kit.lock
+++ b/generated/css-modules-kit.lock
@@ -316,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -399,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -501,9 +501,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/d.lock
+++ b/generated/d.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/devicetree.lock
+++ b/generated/devicetree.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/fortran.lock
+++ b/generated/fortran.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/gdscript.lock
+++ b/generated/gdscript.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",

--- a/generated/harper.lock
+++ b/generated/harper.lock
@@ -50,9 +50,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/helm.lock
+++ b/generated/helm.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/iwe.lock
+++ b/generated/iwe.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/java.lock
+++ b/generated/java.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",

--- a/generated/lean4.lock
+++ b/generated/lean4.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/luau.lock
+++ b/generated/luau.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -165,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/mcp-planetscale.lock
+++ b/generated/mcp-planetscale.lock
@@ -314,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -406,9 +406,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -543,9 +543,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/mcp-server-buildkite.lock
+++ b/generated/mcp-server-buildkite.lock
@@ -314,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",

--- a/generated/mcp-server-mui.lock
+++ b/generated/mcp-server-mui.lock
@@ -314,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",

--- a/generated/meson.lock
+++ b/generated/meson.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/motoko.lock
+++ b/generated/motoko.lock
@@ -308,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -493,9 +493,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/neocmake.lock
+++ b/generated/neocmake.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/nim.lock
+++ b/generated/nim.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/norminette.lock
+++ b/generated/norminette.lock
@@ -73,9 +73,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -222,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/pact.lock
+++ b/generated/pact.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/python-refactoring.lock
+++ b/generated/python-refactoring.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/r.lock
+++ b/generated/r.lock
@@ -308,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -500,9 +500,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/rego.lock
+++ b/generated/rego.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/roc.lock
+++ b/generated/roc.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/rst.lock
+++ b/generated/rst.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/scala.lock
+++ b/generated/scala.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/sieve.lock
+++ b/generated/sieve.lock
@@ -308,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -493,9 +493,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/sqruff.lock
+++ b/generated/sqruff.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/stimulus.lock
+++ b/generated/stimulus.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/templ.lock
+++ b/generated/templ.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/ty.lock
+++ b/generated/ty.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/typos.lock
+++ b/generated/typos.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/v.lock
+++ b/generated/v.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/vala.lock
+++ b/generated/vala.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/generated/yara.lock
+++ b/generated/yara.lock
@@ -43,9 +43,9 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -78,18 +78,25 @@ final: prev: {
             ;
         };
 
-        postPatch = lib.optionalString (extension.kind == "rust" && extension ? cargoLock) ''
-          cp ${../. + extension.cargoLock.lockFile} Cargo.lock
-        '';
-
         extensionRoot = if extension ? extensionRoot then extension.extensionRoot else null;
         grammars = map (id: zed-grammars."${id}") extension.grammars;
       }
       // lib.optionalAttrs (extension.kind == "rust") {
-        useFetchCargoVendor = true;
         cargoHash = extension.cargoHash;
       }
+      // lib.optionalAttrs (extension.kind == "rust" && extension ? cargoRoot) {
+        cargoRoot = extension.cargoRoot;
+      }
       // lib.optionalAttrs (extension.kind == "rust" && extension ? cargoLock) {
+        postPatch = ''
+          ${
+            if extension ? cargoRoot then
+              "cp ${../. + extension.cargoLock.lockFile} ${extension.cargoRoot}/Cargo.lock"
+            else
+              "cp ${../. + extension.cargoLock.lockFile} Cargo.lock"
+          }
+        '';
+
         cargoLock = {
           lockFile = ../. + extension.cargoLock.lockFile;
           outputHashes = extension.cargoLock.outputHashes or { };

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+NIXPKGS=${1:-nixpkgs}
+
+# CLI
+nix build .#nix-zed-extensions \
+  --quiet \
+  --inputs-from . \
+  --override-input nixpkgs $NIXPKGS
+
+# Plain
+nix build .#zed-extensions.catppuccin \
+  --quiet \
+  --inputs-from . \
+  --override-input nixpkgs $NIXPKGS
+
+tree result/share/zed/extensions/catppuccin
+test -f result/share/zed/extensions/catppuccin/extension.toml
+test -d result/share/zed/extensions/catppuccin/themes
+
+# Rust
+nix build .#zed-extensions.nix \
+  --quiet \
+  --inputs-from . \
+  --override-input nixpkgs $NIXPKGS
+
+tree result/share/zed/extensions/nix
+test -f result/share/zed/extensions/nix/extension.toml
+test -f result/share/zed/extensions/nix/extension.wasm
+test -d result/share/zed/extensions/nix/grammars
+test -d result/share/zed/extensions/nix/languages
+
+# Monorepo Plain
+nix build .#zed-extensions.aura-theme \
+  --quiet \
+  --inputs-from . \
+  --override-input nixpkgs $NIXPKGS
+
+tree result/share/zed/extensions/aura-theme
+test -f result/share/zed/extensions/aura-theme/extension.toml
+test -d result/share/zed/extensions/aura-theme/themes
+
+# Monorepo Rust
+nix build .#zed-extensions.toml \
+  --quiet \
+  --inputs-from . \
+  --override-input nixpkgs $NIXPKGS
+
+tree result/share/zed/extensions/toml
+test -f result/share/zed/extensions/toml/extension.toml
+test -f result/share/zed/extensions/toml/extension.wasm
+test -d result/share/zed/extensions/toml/grammars
+test -d result/share/zed/extensions/toml/languages
+
+# Workspace Rust
+nix build .#zed-extensions.deputy \
+  --quiet \
+  --inputs-from . \
+  --override-input nixpkgs $NIXPKGS
+
+tree result/share/zed/extensions/deputy
+test -f result/share/zed/extensions/deputy/extension.toml
+test -f result/share/zed/extensions/deputy/extension.wasm

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,12 @@ async fn main() -> anyhow::Result<()> {
             };
 
             tracing::info!("Cloning extensions registry");
+
             let tmp_registry = temp_dir().join("registry");
+            if tmp_registry.exists() {
+                fs::remove_dir_all(&tmp_registry).await?;
+            }
+
             let clone = Command::new("git")
                 .args([
                     "clone",

--- a/src/output.rs
+++ b/src/output.rs
@@ -26,6 +26,8 @@ pub enum ExtensionKind {
     Plain,
 
     Rust {
+        #[serde(rename = "cargoRoot", skip_serializing_if = "Option::is_none")]
+        cargo_root: Option<String>,
         #[serde(rename = "cargoHash")]
         cargo_hash: String,
         #[serde(rename = "cargoLock", skip_serializing_if = "Option::is_none")]

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,2 @@
+[files]
+extend-exclude = ["extensions.json"]


### PR DESCRIPTION
More complicated that I'd like it to be, but appears to work.

Also dropped support for nixpkgs-deprecated.
Wasn't planning to, but seems to be producing a different lockfile hash on occasion.
Plus the 24.11 end of life is in 3 days anyways.