### PR TITLE
don't overwrite package name with extension name

### DIFF
--- a/pkgs/buildZedExtension/default.nix
+++ b/pkgs/buildZedExtension/default.nix
@@ -34,7 +34,7 @@ lib.extendMkDerivation {
     in
     {
       pname = "zed-extension-${name}";
-      inherit name src version;
+      inherit src version;
 
       nativeBuildInputs = [
         nix-zed-extensions

--- a/pkgs/buildZedGrammar/default.nix
+++ b/pkgs/buildZedGrammar/default.nix
@@ -31,7 +31,7 @@ lib.extendMkDerivation {
     in
     {
       pname = "zed-grammar-${name}";
-      inherit name src version;
+      inherit src version;
 
       nativeBuildInputs = [
         wasi-sdk

--- a/pkgs/buildZedRustExtension/default.nix
+++ b/pkgs/buildZedRustExtension/default.nix
@@ -48,7 +48,6 @@ lib.extendMkDerivation {
     {
       pname = "zed-extension-${name}";
       inherit
-        name
         src
         version
         cargoRoot


### PR DESCRIPTION
Because the current derivations set the `name`, the final package name will be something like `nix` instead of `zed-extensions-nix-0.1.4`.

By only setting the `pname` `mkDerivation` will create the final name from `pname` and `version` as usual.