### PR TITLE
Use fetch-cargo-vendor v2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779102034,
-        "narHash": "sha256-vZJZjLo513IeI8hjzHFc6TDezUd4uCE2Eq4SNO3DNNg=",
+        "lastModified": 1780952837,
+        "narHash": "sha256-Fwd1+spDtQ0hDyBwme6ufG3n4mY0UrjjFdYHv+G/Hds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "687f05a9184cad4eaf905c48b63649e3a86f5433",
+        "rev": "e820eb4a444b46a19b2e03e8dfd2359439ff30fe",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1779333539,
-        "narHash": "sha256-lpmN2lrBDZDPjov2cbD3bOOJsI0fkKolKXasYPCqSys=",
+        "lastModified": 1781234414,
+        "narHash": "sha256-HdA+P4fKRGOomkewnI/Tww5Wz4xK1O7+hDO90YAsPB4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "672fa5fc5608d5cd82286a6f69aaf84a40b4fe41",
+        "rev": "1d18bfe3de6244c641ca4e8011186d0981b81d76",
         "type": "github"
       },
       "original": {

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -9,14 +9,26 @@ final: prev: {
 
   # Allow pre-fetching cargoHash.
   # https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/rust/fetch-cargo-vendor.nix
-  fetch-cargo-vendor-util = prev.writers.writePython3Bin "fetch-cargo-vendor-util-v2" {
-    libraries = with prev.python3Packages; [
-      requests
-    ];
-    flakeIgnore = [
-      "E501"
-    ];
-  } (builtins.readFile "${prev.path}/pkgs/build-support/rust/fetch-cargo-vendor-util-v2.py");
+  # Prefer 'v2' script if exists.
+  fetch-cargo-vendor-util =
+    prev.writers.writePython3Bin "fetch-cargo-vendor-util"
+      {
+        libraries = with prev.python3Packages; [
+          requests
+        ];
+        flakeIgnore = [
+          "E501"
+        ];
+      }
+
+      (
+        builtins.readFile (
+          if builtins.pathExists "${prev.path}/pkgs/build-support/rust/fetch-cargo-vendor-util-v2.py" then
+            "${prev.path}/pkgs/build-support/rust/fetch-cargo-vendor-util-v2.py"
+          else
+            "${prev.path}/pkgs/build-support/rust/fetch-cargo-vendor-util.py"
+        )
+      );
 
   mkZedGrammar =
     grammar:

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -9,14 +9,14 @@ final: prev: {
 
   # Allow pre-fetching cargoHash.
   # https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/rust/fetch-cargo-vendor.nix
-  fetch-cargo-vendor-util = prev.writers.writePython3Bin "fetch-cargo-vendor-util" {
+  fetch-cargo-vendor-util = prev.writers.writePython3Bin "fetch-cargo-vendor-util-v2" {
     libraries = with prev.python3Packages; [
       requests
     ];
     flakeIgnore = [
       "E501"
     ];
-  } (builtins.readFile "${prev.path}/pkgs/build-support/rust/fetch-cargo-vendor-util.py");
+  } (builtins.readFile "${prev.path}/pkgs/build-support/rust/fetch-cargo-vendor-util-v2.py");
 
   mkZedGrammar =
     grammar:

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -13,9 +13,14 @@ final: prev: {
   fetch-cargo-vendor-util =
     prev.writers.writePython3Bin "fetch-cargo-vendor-util"
       {
-        libraries = with prev.python3Packages; [
-          requests
-        ];
+        libraries =
+          with prev.python3Packages;
+          [
+            requests
+            tomli-w
+          ]
+          ++ requests.optional-dependencies.socks; # to support socks proxy envs like ALL_PROXY in requests
+
         flakeIgnore = [
           "E501"
         ];

--- a/src/sync/rust.rs
+++ b/src/sync/rust.rs
@@ -197,7 +197,7 @@ async fn generate_cargo_hash(name: &str, lockfile: &Path) -> anyhow::Result<Stri
         "Running Cargo vendor"
     );
 
-    let vendor = Command::new("fetch-cargo-vendor-util-v2")
+    let vendor = Command::new("fetch-cargo-vendor-util")
         .args([
             "create-vendor-staging",
             &lockfile.to_string_lossy(),

--- a/src/sync/rust.rs
+++ b/src/sync/rust.rs
@@ -197,7 +197,7 @@ async fn generate_cargo_hash(name: &str, lockfile: &Path) -> anyhow::Result<Stri
         "Running Cargo vendor"
     );
 
-    let vendor = Command::new("fetch-cargo-vendor-util")
+    let vendor = Command::new("fetch-cargo-vendor-util-v2")
         .args([
             "create-vendor-staging",
             &lockfile.to_string_lossy(),


### PR DESCRIPTION
The vendor fetching is hitting 403s from crates.io, which causes extensions to [get removed](https://github.com/DuskSystems/nix-zed-extensions/commit/94af72006d4b31e5b4fd09de712dbec732f1322a). Using the v2 script from NixOS/nixpkgs#512735 should make the fetcher more reliable.
